### PR TITLE
Fix compilation error with recent glibc

### DIFF
--- a/src/corepoint.c
+++ b/src/corepoint.c
@@ -228,7 +228,7 @@ static void trapSignalHandler(int iSignal, siginfo_t* iSignalInfo __attribute__(
     /* Prevent gcc from optimizing out the context pointer with "volatile", so that we can
      * easily access it in the generated core dump for analyzing the real context (ie registers)
      * at the moment the core point was reached. */
-    volatile struct ucontext* aContext = (struct ucontext*)ioVoidContext;
+    volatile struct ucontext_t* aContext = (struct ucontext_t*)ioVoidContext;
     volatile struct kernel_sigcontext* aReturnRegisters = (struct kernel_sigcontext*)&aContext->uc_mcontext;
 
     if (iSignal == SIGTRAP)

--- a/src/elfcore.h
+++ b/src/elfcore.h
@@ -280,7 +280,7 @@ extern "C" {
     do { \
       f.errno_ = errno; \
       f.tid    = sys_gettid(); \
-      struct ucontext* ucontext = (struct ucontext*)(ucontext_void_ptr); \
+      struct ucontext_t* ucontext = (struct ucontext_t*)(ucontext_void_ptr); \
       struct kernel_sigcontext* sigcontext = (struct kernel_sigcontext*)&ucontext->uc_mcontext; \
       f.uregs.r8 = sigcontext->r8; \
       f.uregs.r9 = sigcontext->r9; \


### PR DESCRIPTION
ucontext type must not be used since they change to ucontext_t for POSIX compilance improvement.

Can you deliver a new release ?